### PR TITLE
Add page management endpoints and bulk post operations

### DIFF
--- a/app/Http/Controllers/PageManagementController.php
+++ b/app/Http/Controllers/PageManagementController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\BulkTemplateRequest;
+use App\Http\Requests\BulkToggleRequest;
+use App\Models\CommentLog;
+use App\Models\Page;
+use App\Models\Post;
+use App\Models\PostTemplate;
+use App\Models\PageSubscription;
+use App\Services\GraphService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PageManagementController extends Controller
+{
+    public function destroy($page_id)
+    {
+        $page = Page::where('page_id', $page_id)->firstOrFail();
+        $this->authorize('manage', $page);
+
+        DB::transaction(function () use ($page) {
+            PostTemplate::whereIn('post_id', Post::where('page_id', $page->id)->pluck('post_id'))->delete();
+            CommentLog::where('page_id', $page->id)->delete();
+            Post::where('page_id', $page->id)->delete();
+            $page->delete();
+        });
+
+        return response()->json(['deleted' => true]);
+    }
+
+    public function resubscribe($page_id, GraphService $graph)
+    {
+        $page = Page::where('page_id', $page_id)->firstOrFail();
+        $this->authorize('manage', $page);
+
+        $graph->subscribePageWebhooks($page->page_id, $page->access_token);
+        return response()->json(['resubscribed' => true]);
+    }
+
+    public function bulkToggle(BulkToggleRequest $request, $page_id)
+    {
+        $page = Page::where('page_id', $page_id)->firstOrFail();
+        $this->authorize('manage', $page);
+
+        $ids    = $request->validated()['post_ids'];
+        $enable = $request->boolean('enable');
+
+        if ($enable) {
+            $sub = PageSubscription::where('page_id', $page->id)->whereNull('ends_at')->with('plan')->first();
+            if ($sub) {
+                $activeCount = Post::where('page_id', $page->id)->where('is_active', true)->count();
+                $remaining   = max(0, $sub->plan->max_active_posts - $activeCount);
+                if ($remaining <= 0) {
+                    return response()->json(['error' => 'Active posts limit reached'], 422);
+                }
+                $ids = array_slice($ids, 0, $remaining);
+            }
+        }
+
+        Post::where('page_id', $page->id)->whereIn('post_id', $ids)->update(['is_active' => $enable]);
+        return response()->json(['updated' => count($ids), 'enable' => $enable]);
+    }
+
+    public function bulkTemplate(BulkTemplateRequest $request, $page_id)
+    {
+        $page = Page::where('page_id', $page_id)->firstOrFail();
+        $this->authorize('manage', $page);
+
+        $data  = $request->validated();
+        $count = 0;
+
+        foreach ($data['post_ids'] as $pid) {
+            PostTemplate::updateOrCreate(
+                ['page_id' => $page->id, 'post_id' => $pid],
+                [
+                    'private_reply_template' => $data['private_reply_template'] ?? '',
+                    'public_reply_template'  => $data['public_reply_template'] ?? null,
+                    'is_active'              => true,
+                ]
+            );
+            $count++;
+        }
+
+        return response()->json(['updated' => $count]);
+    }
+
+    public function logs(Request $request, $page_id)
+    {
+        $page = Page::where('page_id', $page_id)->firstOrFail();
+        $this->authorize('view', $page);
+
+        $q = CommentLog::where('page_id', $page->id);
+
+        if ($status = $request->get('status')) {
+            $q->where('status', $status);
+        }
+        if ($term = $request->get('q')) {
+            $q->where(function ($w) use ($term) {
+                $w->where('comment_id', 'like', "%{$term}%")
+                  ->orWhere('post_id', 'like', "%{$term}%")
+                  ->orWhere('error_message', 'like', "%{$term}%");
+            });
+        }
+
+        return response()->json($q->orderByDesc('id')->paginate(30));
+    }
+}

--- a/app/Http/Requests/BulkTemplateRequest.php
+++ b/app/Http/Requests/BulkTemplateRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BulkTemplateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'post_ids'               => 'required|array|min:1',
+            'post_ids.*'             => 'required|string',
+            'private_reply_template' => 'nullable|string',
+            'public_reply_template'  => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/BulkToggleRequest.php
+++ b/app/Http/Requests/BulkToggleRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BulkToggleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'post_ids'   => 'required|array|min:1',
+            'post_ids.*' => 'required|string',
+            'enable'     => 'required|boolean',
+        ];
+    }
+}

--- a/app/Services/GraphService.php
+++ b/app/Services/GraphService.php
@@ -43,4 +43,14 @@ class GraphService
 
         return $resp['data'] ?? [];
     }
+
+    public function subscribePageWebhooks(string $pageId, string $pageAccessToken): array
+    {
+        $resp = Http::asForm()->post("{$this->base}/{$pageId}/subscribed_apps", [
+            'subscribed_fields' => 'feed,messages,message_echoes',
+            'access_token'      => $pageAccessToken,
+        ]);
+
+        return $resp->json();
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\PostController;
 use App\Http\Controllers\TemplateController;
 use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SubscriptionController;
+use App\Http\Controllers\PageManagementController;
 use App\Models\Shop;
 
 Route::middleware('auth:sanctum')->group(function () {
@@ -23,18 +24,24 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::middleware('can:isAdmin')->apiResource('plans', PlanController::class);
 
     Route::prefix('pages/{page_id}')->middleware('page.owner')->group(function () {
-        Route::post('posts/import', [PostController::class, 'import']);
-        Route::get('posts', [PostController::class, 'index']);
-        Route::patch('posts/{post_id}/toggle', [PostController::class, 'toggle']);
+          Route::post('posts/import', [PostController::class, 'import']);
+          Route::get('posts', [PostController::class, 'index']);
+          Route::patch('posts/{post_id}/toggle', [PostController::class, 'toggle']);
 
-        Route::get('posts/{post_id}/template', [TemplateController::class, 'show']);
-        Route::post('posts/{post_id}/template', [TemplateController::class, 'store']);
-        Route::put('posts/{post_id}/template', [TemplateController::class, 'update']);
-        Route::delete('posts/{post_id}/template', [TemplateController::class, 'destroy']);
+          Route::get('posts/{post_id}/template', [TemplateController::class, 'show']);
+          Route::post('posts/{post_id}/template', [TemplateController::class, 'store']);
+          Route::put('posts/{post_id}/template', [TemplateController::class, 'update']);
+          Route::delete('posts/{post_id}/template', [TemplateController::class, 'destroy']);
 
-        Route::post('subscribe', [SubscriptionController::class, 'subscribe']);
-        Route::post('unsubscribe', [SubscriptionController::class, 'unsubscribe']);
-        Route::get('subscription', [SubscriptionController::class, 'current']);
-        Route::get('quota', [SubscriptionController::class, 'quota']);
-    });
-});
+          Route::post('subscribe', [SubscriptionController::class, 'subscribe']);
+          Route::post('unsubscribe', [SubscriptionController::class, 'unsubscribe']);
+          Route::get('subscription', [SubscriptionController::class, 'current']);
+          Route::get('quota', [SubscriptionController::class, 'quota']);
+
+          Route::delete('/', [PageManagementController::class, 'destroy']);
+          Route::post('resubscribe', [PageManagementController::class, 'resubscribe']);
+          Route::patch('posts/bulk-toggle', [PageManagementController::class, 'bulkToggle']);
+          Route::post('posts/bulk-template', [PageManagementController::class, 'bulkTemplate']);
+          Route::get('logs', [PageManagementController::class, 'logs']);
+      });
+  });


### PR DESCRIPTION
## Summary
- add requests for bulk post toggling and templating
- support page webhook resubscription in GraphService
- implement PageManagementController with delete, resubscribe, bulk post actions, and logs
- register page management routes

## Testing
- `composer install --no-interaction --no-progress` *(fails: Required packages not present in lock file)*
- `composer update --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab076496b08333a47ee9cc9abedc80