### PR TITLE
Add Swagger docs and feature tests for page management

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,6 +10,11 @@ namespace App\Http\Controllers;
  *   scheme="bearer",
  *   bearerFormat="JWT"
  * )
+ * @OA\Tag(name="Pages", description="Facebook pages management")
+ * @OA\Tag(name="Posts", description="Posts import & toggle")
+ * @OA\Tag(name="Templates", description="Templates per post")
+ * @OA\Tag(name="Subscriptions", description="Plans & quotas")
+ * @OA\Tag(name="Logs", description="Delivery logs")
  */
 abstract class Controller
 {

--- a/app/Http/Controllers/PageManagementController.php
+++ b/app/Http/Controllers/PageManagementController.php
@@ -6,15 +6,27 @@ use App\Http\Requests\BulkTemplateRequest;
 use App\Http\Requests\BulkToggleRequest;
 use App\Models\CommentLog;
 use App\Models\Page;
+use App\Models\PageSubscription;
 use App\Models\Post;
 use App\Models\PostTemplate;
-use App\Models\PageSubscription;
 use App\Services\GraphService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class PageManagementController extends Controller
 {
+    /**
+     * @OA\Delete(
+     *   path="/api/pages/{page_id}",
+     *   tags={"Pages"},
+     *   summary="Delete a page locally (not on Facebook)",
+     *   security={{"bearerAuth":{}}},
+     *   @OA\Parameter(name="page_id", in="path", required=true, @OA\Schema(type="string")),
+     *   @OA\Response(response=200, description="Deleted"),
+     *   @OA\Response(response=403, description="Forbidden"),
+     *   @OA\Response(response=404, description="Not found")
+     * )
+     */
     public function destroy($page_id)
     {
         $page = Page::where('page_id', $page_id)->firstOrFail();
@@ -30,6 +42,18 @@ class PageManagementController extends Controller
         return response()->json(['deleted' => true]);
     }
 
+    /**
+     * @OA\Post(
+     *   path="/api/pages/{page_id}/resubscribe",
+     *   tags={"Pages"},
+     *   summary="Re-subscribe page webhooks (feed,messages)",
+     *   security={{"bearerAuth":{}}},
+     *   @OA\Parameter(name="page_id", in="path", required=true, @OA\Schema(type="string")),
+     *   @OA\Response(response=200, description="Resubscribed"),
+     *   @OA\Response(response=403, description="Forbidden"),
+     *   @OA\Response(response=404, description="Not found")
+     * )
+     */
     public function resubscribe($page_id, GraphService $graph)
     {
         $page = Page::where('page_id', $page_id)->firstOrFail();
@@ -39,6 +63,25 @@ class PageManagementController extends Controller
         return response()->json(['resubscribed' => true]);
     }
 
+    /**
+     * @OA\Patch(
+     *   path="/api/pages/{page_id}/posts/bulk-toggle",
+     *   tags={"Posts"},
+     *   summary="Bulk enable/disable posts for a page",
+     *   security={{"bearerAuth":{}}},
+     *   @OA\Parameter(name="page_id", in="path", required=true, @OA\Schema(type="string")),
+     *   @OA\RequestBody(
+     *     required=true,
+     *     @OA\JsonContent(
+     *       @OA\Property(property="post_ids", type="array", @OA\Items(type="string")),
+     *       @OA\Property(property="enable", type="boolean")
+     *     )
+     *   ),
+     *   @OA\Response(response=200, description="Updated"),
+     *   @OA\Response(response=422, description="Plan limit reached/validation"),
+     *   @OA\Response(response=403, description="Forbidden")
+     * )
+     */
     public function bulkToggle(BulkToggleRequest $request, $page_id)
     {
         $page = Page::where('page_id', $page_id)->firstOrFail();
@@ -63,6 +106,25 @@ class PageManagementController extends Controller
         return response()->json(['updated' => count($ids), 'enable' => $enable]);
     }
 
+    /**
+     * @OA\Post(
+     *   path="/api/pages/{page_id}/posts/bulk-template",
+     *   tags={"Templates"},
+     *   summary="Bulk apply templates to many posts",
+     *   security={{"bearerAuth":{}}},
+     *   @OA\Parameter(name="page_id", in="path", required=true, @OA\Schema(type="string")),
+     *   @OA\RequestBody(
+     *     required=true,
+     *     @OA\JsonContent(
+     *       @OA\Property(property="post_ids", type="array", @OA\Items(type="string")),
+     *       @OA\Property(property="private_reply_template", type="string"),
+     *       @OA\Property(property="public_reply_template", type="string")
+     *     )
+     *   ),
+     *   @OA\Response(response=200, description="Updated"),
+     *   @OA\Response(response=403, description="Forbidden")
+     * )
+     */
     public function bulkTemplate(BulkTemplateRequest $request, $page_id)
     {
         $page = Page::where('page_id', $page_id)->firstOrFail();
@@ -86,6 +148,18 @@ class PageManagementController extends Controller
         return response()->json(['updated' => $count]);
     }
 
+    /**
+     * @OA\Get(
+     *   path="/api/pages/{page_id}/logs",
+     *   tags={"Logs"},
+     *   summary="List comment delivery logs with filters",
+     *   security={{"bearerAuth":{}}},
+     *   @OA\Parameter(name="page_id", in="path", required=true, @OA\Schema(type="string")),
+     *   @OA\Parameter(name="status", in="query", @OA\Schema(type="string", enum={"sent","failed","skipped"})),
+     *   @OA\Parameter(name="q", in="query", @OA\Schema(type="string")),
+     *   @OA\Response(response=200, description="OK")
+     * )
+     */
     public function logs(Request $request, $page_id)
     {
         $page = Page::where('page_id', $page_id)->firstOrFail();
@@ -99,11 +173,12 @@ class PageManagementController extends Controller
         if ($term = $request->get('q')) {
             $q->where(function ($w) use ($term) {
                 $w->where('comment_id', 'like', "%{$term}%")
-                  ->orWhere('post_id', 'like', "%{$term}%")
-                  ->orWhere('error_message', 'like', "%{$term}%");
+                    ->orWhere('post_id', 'like', "%{$term}%")
+                    ->orWhere('error_message', 'like', "%{$term}%");
             });
         }
 
         return response()->json($q->orderByDesc('id')->paginate(30));
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.1",
-        "phpunit/phpunit": "^11.0.1"
+        "phpunit/phpunit": "^11.0.1",
+        "pestphp/pest": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/database/factories/CommentLogFactory.php
+++ b/database/factories/CommentLogFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CommentLog;
+use App\Models\Page;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class CommentLogFactory extends Factory
+{
+    protected $model = CommentLog::class;
+
+    public function definition(): array
+    {
+        return [
+            'comment_id' => Str::uuid()->toString(),
+            'page_id' => Page::factory(),
+            'post_id' => Str::uuid()->toString(),
+            'status' => 'sent',
+            'error_code' => null,
+            'error_message' => null,
+            'sent_at' => now(),
+        ];
+    }
+}
+

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Page;
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class PageFactory extends Factory
+{
+    protected $model = Page::class;
+
+    public function definition(): array
+    {
+        return [
+            'shop_id' => Shop::factory(),
+            'page_id' => fake()->unique()->numerify('########'),
+            'name' => fake()->company(),
+            'access_token' => Str::random(40),
+        ];
+    }
+}
+

--- a/database/factories/PageSubscriptionFactory.php
+++ b/database/factories/PageSubscriptionFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Page;
+use App\Models\PageSubscription;
+use App\Models\Plan;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PageSubscriptionFactory extends Factory
+{
+    protected $model = PageSubscription::class;
+
+    public function definition(): array
+    {
+        return [
+            'page_id' => Page::factory(),
+            'plan_id' => Plan::factory(),
+            'starts_at' => now()->toDateString(),
+            'ends_at' => null,
+        ];
+    }
+}
+

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Plan;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PlanFactory extends Factory
+{
+    protected $model = Plan::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->word(),
+            'max_active_posts' => 10,
+            'daily_private_replies' => 200,
+            'monthly_private_replies' => 3000,
+        ];
+    }
+}
+

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use App\Models\Page;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    public function definition(): array
+    {
+        return [
+            'page_id' => Page::factory(),
+            'post_id' => Str::uuid()->toString(),
+            'permalink_url' => fake()->url(),
+            'title' => fake()->sentence(),
+            'is_active' => true,
+        ];
+    }
+}
+

--- a/database/factories/ShopFactory.php
+++ b/database/factories/ShopFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Shop;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ShopFactory extends Factory
+{
+    protected $model = Shop::class;
+
+    public function definition(): array
+    {
+        return [
+            'owner_id' => User::factory(),
+            'name' => fake()->company(),
+        ];
+    }
+}
+

--- a/tests/Feature/PageManagementTest.php
+++ b/tests/Feature/PageManagementTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Models\User;
+use App\Models\Shop;
+use App\Models\Page;
+use App\Models\Post;
+use App\Models\Plan;
+use App\Models\PageSubscription;
+use App\Models\CommentLog;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\{deleteJson, postJson, patchJson, getJson};
+
+it('deletes a page and related records', function(){
+    $user = User::factory()->create();
+    $shop = Shop::factory()->create(['owner_id'=>$user->id]);
+    $page = Page::factory()->create(['shop_id'=>$shop->id]);
+
+    $posts = Post::factory()->count(3)->create(['page_id'=>$page->id]);
+    CommentLog::factory()->count(2)->create(['page_id'=>$page->id, 'post_id'=>$posts->first()->post_id]);
+
+    Sanctum::actingAs($user);
+
+    deleteJson("/api/pages/{$page->page_id}")
+        ->assertOk()
+        ->assertJson(['deleted'=>true]);
+
+    expect(Page::whereKey($page->id)->exists())->toBeFalse();
+    expect(Post::where('page_id',$page->id)->count())->toBe(0);
+    expect(CommentLog::where('page_id',$page->id)->count())->toBe(0);
+});
+
+it('resubscribes a page webhooks (requires manage)', function(){
+    $user = User::factory()->create();
+    $shop = Shop::factory()->create(['owner_id'=>$user->id]);
+    $page = Page::factory()->create(['shop_id'=>$shop->id]);
+
+    Sanctum::actingAs($user);
+
+    $this->mock(\App\Services\GraphService::class, function($m){
+        $m->shouldReceive('subscribePageWebhooks')->once()->andReturn(['success'=>true]);
+    });
+
+    postJson("/api/pages/{$page->page_id}/resubscribe")->assertOk();
+});
+
+it('bulk enables posts with plan limit', function(){
+    $user = User::factory()->create();
+    $shop = Shop::factory()->create(['owner_id'=>$user->id]);
+    $page = Page::factory()->create(['shop_id'=>$shop->id]);
+
+    $plan = Plan::factory()->create(['max_active_posts'=>2, 'daily_private_replies'=>100, 'monthly_private_replies'=>1000]);
+    PageSubscription::factory()->create(['page_id'=>$page->id, 'plan_id'=>$plan->id, 'starts_at'=>now()->toDateString(), 'ends_at'=>null]);
+
+    $p1 = Post::factory()->create(['page_id'=>$page->id, 'is_active'=>false]);
+    $p2 = Post::factory()->create(['page_id'=>$page->id, 'is_active'=>false]);
+    $p3 = Post::factory()->create(['page_id'=>$page->id, 'is_active'=>false]);
+
+    Sanctum::actingAs($user);
+
+    patchJson("/api/pages/{$page->page_id}/posts/bulk-toggle", [
+        'post_ids' => [$p1->post_id, $p2->post_id, $p3->post_id],
+        'enable' => true
+    ])->assertOk()->assertJson(['updated'=>2]);
+
+    expect(Post::where('id',$p1->id)->value('is_active'))->toBeTrue();
+    expect(Post::where('id',$p2->id)->value('is_active'))->toBeTrue();
+    expect(Post::where('id',$p3->id)->value('is_active'))->toBeFalse();
+});
+
+it('bulk applies template to many posts', function(){
+    $user = User::factory()->create();
+    $shop = Shop::factory()->create(['owner_id'=>$user->id]);
+    $page = Page::factory()->create(['shop_id'=>$shop->id]);
+    $posts = Post::factory()->count(3)->create(['page_id'=>$page->id, 'is_active'=>true]);
+
+    Sanctum::actingAs($user);
+
+    postJson("/api/pages/{$page->page_id}/posts/bulk-template", [
+        'post_ids' => $posts->pluck('post_id')->all(),
+        'private_reply_template' => "Price: {price}\n{post_url}",
+        'public_reply_template' => 'Thanks for your comment!'
+    ])->assertOk()->assertJson(['updated'=>3]);
+});
+
+it('lists logs with filters', function(){
+    $user = User::factory()->create();
+    $shop = Shop::factory()->create(['owner_id'=>$user->id]);
+    $page = Page::factory()->create(['shop_id'=>$shop->id]);
+
+    CommentLog::factory()->create(['page_id'=>$page->id, 'status'=>'sent', 'comment_id'=>'c1', 'post_id'=>'p1']);
+    CommentLog::factory()->create(['page_id'=>$page->id, 'status'=>'failed', 'comment_id'=>'c2', 'post_id'=>'p2', 'error_message'=>'Quota exceeded']);
+
+    Sanctum::actingAs($user);
+
+    getJson("/api/pages/{$page->page_id}/logs?status=failed&q=Quota")
+        ->assertOk()
+        ->assertJsonFragment(['status'=>'failed'])
+        ->assertJsonMissing(['status'=>'sent']);
+});
+
+it('forbids non-owner for page actions', function(){
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+    $shop  = Shop::factory()->create(['owner_id'=>$owner->id]);
+    $page  = Page::factory()->create(['shop_id'=>$shop->id]);
+
+    Sanctum::actingAs($other);
+    deleteJson("/api/pages/{$page->page_id}")->assertForbidden();
+});
+

--- a/tests/Feature/concerns.php
+++ b/tests/Feature/concerns.php
@@ -1,0 +1,12 @@
+<?php
+use App\Models\User;
+use App\Models\Shop;
+use App\Models\Page;
+
+function actingAsOwnerWithPage(): array {
+    $user = User::factory()->create();
+    $shop = Shop::factory()->create(['owner_id' => $user->id]);
+    $page = Page::factory()->create(['shop_id' => $shop->id]);
+    return [$user, $shop, $page];
+}
+

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class)->in('Feature');
+


### PR DESCRIPTION
## Summary
- document page management endpoints with Swagger annotations
- add model factories and Pest feature tests for page operations
- declare global Swagger tags and enable Pest in composer

## Testing
- `php artisan l5-swagger:generate` *(fails: require vendor/autoload.php)*
- `php artisan test --testsuite=Feature` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ab098480c88333904241852daaf37b