### PR TITLE
refine factories and add demo seeder

### DIFF
--- a/database/factories/CommentLogFactory.php
+++ b/database/factories/CommentLogFactory.php
@@ -5,7 +5,6 @@ namespace Database\Factories;
 use App\Models\CommentLog;
 use App\Models\Page;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 
 class CommentLogFactory extends Factory
 {
@@ -14,13 +13,12 @@ class CommentLogFactory extends Factory
     public function definition(): array
     {
         return [
-            'comment_id' => Str::uuid()->toString(),
             'page_id' => Page::factory(),
-            'post_id' => Str::uuid()->toString(),
-            'status' => 'sent',
-            'error_code' => null,
-            'error_message' => null,
-            'sent_at' => now(),
+            'post_id' => (string) $this->faker->uuid(),
+            'comment_id' => (string) $this->faker->uuid(),
+            'status' => $this->faker->randomElement(['sent', 'failed', 'skipped']),
+            'error_message' => $this->faker->optional(0.3)->sentence(),
+            'sent_at' => $this->faker->optional()->dateTimeBetween('-2 days', 'now'),
         ];
     }
 }

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -5,7 +5,6 @@ namespace Database\Factories;
 use App\Models\Page;
 use App\Models\Shop;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 
 class PageFactory extends Factory
 {
@@ -13,11 +12,13 @@ class PageFactory extends Factory
 
     public function definition(): array
     {
+        $pid = (string) $this->faker->numberBetween(10000000000, 99999999999);
+
         return [
             'shop_id' => Shop::factory(),
-            'page_id' => fake()->unique()->numerify('########'),
-            'name' => fake()->company(),
-            'access_token' => Str::random(40),
+            'page_id' => $pid,
+            'name' => $this->faker->company(),
+            'access_token' => 'EAAB' . base64_encode($this->faker->uuid()),
         ];
     }
 }

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -12,11 +12,10 @@ class PlanFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'max_active_posts' => 10,
-            'daily_private_replies' => 200,
-            'monthly_private_replies' => 3000,
+            'name' => $this->faker->unique()->randomElement(['Basic','Pro','Scale','Ultra']).' '.$this->faker->randomDigit(),
+            'max_active_posts' => $this->faker->randomElement([5,25,100]),
+            'daily_private_replies' => $this->faker->numberBetween(100, 5000),
+            'monthly_private_replies' => $this->faker->numberBetween(1500, 80000),
         ];
     }
 }
-

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -5,7 +5,6 @@ namespace Database\Factories;
 use App\Models\Post;
 use App\Models\Page;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 
 class PostFactory extends Factory
 {
@@ -15,10 +14,15 @@ class PostFactory extends Factory
     {
         return [
             'page_id' => Page::factory(),
-            'post_id' => Str::uuid()->toString(),
-            'permalink_url' => fake()->url(),
-            'title' => fake()->sentence(),
-            'is_active' => true,
+            'post_id' => function (array $attrs) {
+                $page = Page::find($attrs['page_id']);
+
+                return $page
+                    ? ($page->page_id . '_' . (string) fake()->numberBetween(1000000, 9999999))
+                    : (string) fake()->uuid();
+            },
+            'title' => $this->faker->sentence(3),
+            'is_active' => false,
         ];
     }
 }

--- a/database/factories/ShopFactory.php
+++ b/database/factories/ShopFactory.php
@@ -14,7 +14,7 @@ class ShopFactory extends Factory
     {
         return [
             'owner_id' => User::factory(),
-            'name' => fake()->company(),
+            'name' => $this->faker->company(),
         ];
     }
 }

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\Shop;
+use App\Models\Page;
+use App\Models\Post;
+use App\Models\Plan;
+use App\Models\PageSubscription;
+
+class DemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::factory()->create(['email' => 'demo@example.com']);
+        $shop = Shop::factory()->create(['owner_id' => $user->id, 'name' => 'Demo Shop']);
+        $page = Page::factory()->create(['shop_id' => $shop->id, 'name' => 'Demo Page']);
+        Post::factory()->count(6)->create(['page_id' => $page->id]);
+        $plan = Plan::factory()->create(['name' => 'Pro', 'max_active_posts' => 25]);
+        PageSubscription::factory()->create(['page_id' => $page->id, 'plan_id' => $plan->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- enrich shop, page, post, plan, and comment log factories with realistic data
- add DemoSeeder for quickly populating demo records

## Testing
- `php -l database/factories/ShopFactory.php`
- `php -l database/factories/PageFactory.php`
- `php -l database/factories/PostFactory.php`
- `php -l database/factories/PlanFactory.php`
- `php -l database/factories/CommentLogFactory.php`
- `php -l database/seeders/DemoSeeder.php`
- `php artisan test` *(fails: Failed opening required '/workspace/auto-replay/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68ab0eddadd08333954fb264e88cca19